### PR TITLE
Updating to akka http 10.1.10 and akka 2.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ lazy val `akka-http-rest-client` =
     .settings(settings)
     .settings(
       libraryDependencies ++= Seq(
+        library.akka,
+        library.akkaStream,
         library.akkaHttp,
         library.sprayJson % Test,
         library.scalaTest % Test
@@ -43,12 +45,16 @@ lazy val library =
   new {
 
     object Version {
-      val akkaHttp = "10.0.11"
+      val akka = "2.6.0"
+      val akkaStream = "2.6.0"
+      val akkaHttp = "10.1.10"
       val scalaTest = "3.0.4"
-      val circe = "0.9.3"
+      val circe = "0.11.2"
       val circeAkkaHttp = "1.21.0"
     }
 
+    val akka = "com.typesafe.akka" %% "akka-actor" % Version.akka
+    val akkaStream = "com.typesafe.akka" %% "akka-stream" % Version.akkaStream
     val akkaHttp = "com.typesafe.akka" %% "akka-http" % Version.akkaHttp
     val sprayJson = "com.typesafe.akka" %% "akka-http-spray-json" % Version.akkaHttp
     val circeAkkaHttp = "de.heikoseeberger" %% "akka-http-circe" % Version.circeAkkaHttp
@@ -64,7 +70,7 @@ lazy val settings = projectSettings ++ publishSettings
 
 lazy val projectSettings =
   Seq(
-    scalaVersion := "2.12.7",
+    scalaVersion := "2.12.10",
     organization := "net.softler",
     version := "0.2.1",
     organizationName := "Tobias Frischholz",

--- a/client/akka-http/src/main/scala/net/softler/client/ClientRequest.scala
+++ b/client/akka-http/src/main/scala/net/softler/client/ClientRequest.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Accept
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
-import akka.stream.Materializer
 import net.softler.processor.ResponseProcessor
 
 import scala.annotation.implicitNotFound
@@ -56,14 +55,12 @@ sealed trait IdempotentMethods[R <: RequestState] extends AkkaHttpRequest {
 
   def get()(implicit evidence: RequestIsIdempotent[R],
             system: ActorSystem,
-            materializer: Materializer,
             executionContext: ExecutionContext): Future[ClientResponse] = ClientResponse(
     Http().singleRequest(getRequest)
   )
 
   def get[A](implicit evidence: RequestIsIdempotent[R],
              system: ActorSystem,
-             materializer: Materializer,
              executionContext: ExecutionContext,
              um: Unmarshaller[ResponseEntity, A],
              processor: ResponseProcessor): Future[A] = ClientResponse.as[A](
@@ -72,14 +69,12 @@ sealed trait IdempotentMethods[R <: RequestState] extends AkkaHttpRequest {
 
   def delete()(implicit evidence: RequestIsIdempotent[R],
                system: ActorSystem,
-               materializer: Materializer,
                executionContext: ExecutionContext): Future[ClientResponse] = ClientResponse(
     Http().singleRequest(deletingRequest)
   )
 
   def delete[A](implicit evidence: RequestIsIdempotent[R],
                 system: ActorSystem,
-                materializer: Materializer,
                 executionContext: ExecutionContext,
                 um: Unmarshaller[ResponseEntity, A],
                 processor: ResponseProcessor): Future[A] = ClientResponse.as[A](
@@ -88,14 +83,12 @@ sealed trait IdempotentMethods[R <: RequestState] extends AkkaHttpRequest {
 
   def head()(implicit evidence: RequestIsIdempotent[R],
              system: ActorSystem,
-             materializer: Materializer,
              executionContext: ExecutionContext): Future[ClientResponse] = ClientResponse(
     Http().singleRequest(headRequest)
   )
 
   def head[A](implicit evidence: RequestIsIdempotent[R],
               system: ActorSystem,
-              materializer: Materializer,
               executionContext: ExecutionContext,
               um: Unmarshaller[ResponseEntity, A],
               processor: ResponseProcessor): Future[A] = ClientResponse.as[A](
@@ -104,14 +97,12 @@ sealed trait IdempotentMethods[R <: RequestState] extends AkkaHttpRequest {
 
   def options()(implicit evidence: RequestIsIdempotent[R],
                 system: ActorSystem,
-                materializer: Materializer,
                 executionContext: ExecutionContext): Future[ClientResponse] = ClientResponse(
     Http().singleRequest(optionRequest)
   )
 
   def options[A](implicit evidence: RequestIsIdempotent[R],
                  system: ActorSystem,
-                 materializer: Materializer,
                  executionContext: ExecutionContext,
                  um: Unmarshaller[ResponseEntity, A],
                  processor: ResponseProcessor): Future[A] = ClientResponse.as[A](
@@ -131,13 +122,11 @@ sealed trait UnsafeMethods[R <: RequestState] extends AkkaHttpRequest {
 
   def post()(implicit evidence: RequestWithEntity[R],
              system: ActorSystem,
-             materializer: Materializer,
              executionContext: ExecutionContext): Future[ClientResponse] =
     ClientResponse(Http().singleRequest(postRequest))
 
   def post[A](implicit evidence: RequestWithEntity[R],
               system: ActorSystem,
-              materializer: Materializer,
               executionContext: ExecutionContext,
               um: Unmarshaller[ResponseEntity, A],
               processor: ResponseProcessor): Future[A] = ClientResponse.as[A](
@@ -146,13 +135,11 @@ sealed trait UnsafeMethods[R <: RequestState] extends AkkaHttpRequest {
 
   def put()(implicit evidence: RequestWithEntity[R],
             system: ActorSystem,
-            materializer: Materializer,
             executionContext: ExecutionContext): Future[ClientResponse] =
     ClientResponse(Http().singleRequest(putRequest))
 
   def put[A](implicit evidence: RequestWithEntity[R],
              system: ActorSystem,
-             materializer: Materializer,
              executionContext: ExecutionContext,
              um: Unmarshaller[ResponseEntity, A],
              processor: ResponseProcessor): Future[A] = ClientResponse.as[A](
@@ -161,13 +148,11 @@ sealed trait UnsafeMethods[R <: RequestState] extends AkkaHttpRequest {
 
   def patch()(implicit evidence: RequestWithEntity[R],
               system: ActorSystem,
-              materializer: Materializer,
               executionContext: ExecutionContext): Future[ClientResponse] =
     ClientResponse(Http().singleRequest(patchRequest))
 
   def patch[A](implicit evidence: RequestWithEntity[R],
                system: ActorSystem,
-               materializer: Materializer,
                executionContext: ExecutionContext,
                um: Unmarshaller[ResponseEntity, A],
                processor: ResponseProcessor): Future[A] = ClientResponse.as[A](
@@ -265,7 +250,7 @@ case class ClientRequest[R <: RequestState](request: HttpRequest)
 
   import RequestState._
 
-  def body[A](implicit um: Unmarshaller[RequestEntity, A], materializer: Materializer): Future[A] =
+  def body[A](implicit um: Unmarshaller[RequestEntity, A], as:ActorSystem): Future[A] =
     Unmarshal(request.entity).to[A]
 
   def uri(uri: Uri): ClientRequest[RequestState.Idempotent] = ClientRequest(request.copy(uri = uri))

--- a/client/akka-http/src/test/scala/net/softler/server/HttpServer.scala
+++ b/client/akka-http/src/test/scala/net/softler/server/HttpServer.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.model.TransferEncodings.{deflate, gzip}
 import akka.http.scaladsl.model.headers.`Access-Control-Allow-Methods`
 import akka.http.scaladsl.model.{ContentTypes, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
 import net.softler.marshalling.Models.User
 import net.softler.marshalling.{JsonSupport, Models}
 
@@ -21,8 +20,6 @@ trait HttpServer extends JsonSupport with Models {
   import akka.http.scaladsl.server.Directives._
 
   implicit val system: ActorSystem = ActorSystem("test-actor-system")
-
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.6
+sbt.version=1.3.3

--- a/sample/client/src/main/scala/AkkaHttpClientSample.scala
+++ b/sample/client/src/main/scala/AkkaHttpClientSample.scala
@@ -1,5 +1,4 @@
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
 import net.softler.client.{ClientRequest, ClientResponse, RequestState}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,7 +9,6 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 sealed trait AkkaHttpContext {
   implicit lazy val system: ActorSystem = ActorSystem()
-  implicit lazy val materializer: Materializer = ActorMaterializer()
   implicit lazy val executionContext: ExecutionContext = system.dispatcher
 }
 
@@ -23,8 +21,6 @@ sealed trait AkkaHttpResponse {
 
   implicit def system: ActorSystem
 
-  implicit def materializer: Materializer
-
   implicit def executionContext: ExecutionContext
 
   def request: ClientRequest[RequestState.Idempotent]
@@ -34,9 +30,9 @@ sealed trait AkkaHttpResponse {
 
 sealed trait AkkaHttpResponseHandler {
 
-  implicit def executionContext: ExecutionContext
+  implicit def system: ActorSystem
 
-  implicit def materializer: Materializer
+  implicit def executionContext: ExecutionContext
 
   def response: Future[ClientResponse]
 

--- a/sample/client/src/main/scala/circe/AkkaHttpClientCirceSample.scala
+++ b/sample/client/src/main/scala/circe/AkkaHttpClientCirceSample.scala
@@ -1,7 +1,6 @@
 package circe
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.generic.auto._
 import net.softler.client.ClientRequest
@@ -14,7 +13,6 @@ import scala.concurrent.{ExecutionContext, Future}
 object AkkaHttpClientCirceSample extends App with FailFastCirceSupport {
 
   implicit lazy val system: ActorSystem = ActorSystem()
-  implicit lazy val materializer: Materializer = ActorMaterializer()
   implicit lazy val executionContext: ExecutionContext = system.dispatcher
 
   case class GithubUser(login: String)

--- a/sample/client/src/main/scala/spray/AkkaHttpClientSpraySample.scala
+++ b/sample/client/src/main/scala/spray/AkkaHttpClientSpraySample.scala
@@ -2,7 +2,6 @@ package spray
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.stream.{ActorMaterializer, Materializer}
 import net.softler.client.ClientRequest
 import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
@@ -25,7 +24,6 @@ object AkkaHttpClientJsonSample extends App with JsonSupport {
   import JsonModel._
 
   implicit lazy val system: ActorSystem = ActorSystem()
-  implicit lazy val materializer: Materializer = ActorMaterializer()
   implicit lazy val executionContext: ExecutionContext = system.dispatcher
 
   val clientRequest: Future[GithubUser] = ClientRequest("https://api.github.com/users/Freshwood")


### PR DESCRIPTION
While updating to current versions, I found that I had to explicitly include akka.actor and akka.stream, and then I had to replace all implicit Materializers with implicit ActorSystem (https://doc.akka.io/docs/akka/current/project/migration-guide-2.5.x-2.6.x.html#akka-stream-changes). Hope it's helpful. Looking forward to trying it out!